### PR TITLE
Enable GL renderer

### DIFF
--- a/remotion.config.ts
+++ b/remotion.config.ts
@@ -6,3 +6,4 @@ import {Config} from 'remotion';
 
 Config.Rendering.setImageFormat('jpeg');
 Config.Output.setOverwriteOutput(true);
+Config.Puppeteer.setChromiumOpenGlRenderer('angle');


### PR DESCRIPTION
Hi Jacky!

Awesome animation, congrats! :)
You mentioned on Twitter that the render is slow, and I found that you could greatly benefit from the `--gl=angle` flag which will enable hardware acceleration.

Unfortunately, Chrome also leaks memory with this option, which is why we don't make it the default. But for short local renders, you will not feel that effect.